### PR TITLE
Add support for DM events endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>pom</packaging>
     <name>twitter4j</name>
     <description>A Java library for the Twitter API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -51,18 +51,9 @@
     </mailingLists>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -44,7 +44,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -43,18 +43,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-appengine</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
@@ -87,7 +87,7 @@
     </mailingLists>
     <dependencies>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-appengine</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-appengine</name>
     <description>A Java library for the Twitter API</description>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>

--- a/twitter4j-appengine/src/main/java/twitter4j/AlternativeHttpClientImpl.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/AlternativeHttpClientImpl.java
@@ -85,11 +85,21 @@ class AlternativeHttpClientImpl extends HttpClientBase {
                     write(out, boundary + "--\r\n");
                     write(out, "\r\n");
                 } else {
-                    request.setHeader(new HTTPHeader(
-                            "Content-Type",
-                            "application/x-www-form-urlencoded"
-                    ));
-                    String postParam = HttpParameter.encodeParameters(req.getParameters());
+
+                    String postParam;
+                    if (HttpParameter.containsJson(req.getParameters())) {
+                        request.setHeader(new HTTPHeader(
+                                "Content-Type",
+                                "application/json"
+                        ));
+                        postParam = req.getParameters()[0].getJsonObject().toString();
+                    } else {
+                        request.setHeader(new HTTPHeader(
+                                "Content-Type",
+                                "application/x-www-form-urlencoded"
+                        ));
+                        postParam = HttpParameter.encodeParameters(req.getParameters());
+                    }
                     logger.debug("Post Params: ", postParam);
                     byte[] bytes = postParam.getBytes("UTF-8");
                     request.setHeader(new HTTPHeader("Content-Length",

--- a/twitter4j-appengine/src/main/java/twitter4j/LazyAccountSettings.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyAccountSettings.java
@@ -147,6 +147,11 @@ final class LazyAccountSettings implements twitter4j.AccountSettings {
         return getTarget().getScreenName();
     }
 
+    @Override
+    public String getAllowDmsFrom() {
+        return getTarget().getAllowDmsFrom();
+    }
+
     public RateLimitStatus getRateLimitStatus() {
         return getTarget().getRateLimitStatus();
     }

--- a/twitter4j-appengine/src/main/java/twitter4j/LazyJSONImplFactory.java
+++ b/twitter4j-appengine/src/main/java/twitter4j/LazyJSONImplFactory.java
@@ -199,6 +199,17 @@ class LazyJSONImplFactory implements ObjectFactory {
     }
 
     @Override
+    public DirectMessageEvent createDirectMessageEvent(HttpResponse res) throws TwitterException {
+//        return new LazyDirectMessageEvent(res, factory);
+        throw new TwitterException("Not Implemented");
+    }
+
+    @Override
+    public DirectMessageEventList createDirectMessageEventList(final HttpResponse res) throws TwitterException {
+        throw new TwitterException("Not Implemented");
+    }
+
+    @Override
     public Relationship createRelationship(HttpResponse res) throws TwitterException {
         return new LazyRelationship(res, factory);
     }

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -44,7 +44,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -43,18 +43,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-async</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
@@ -87,7 +87,7 @@
     </mailingLists>
     <dependencies>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-async</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-async</name>
     <description>A Java library for the Twitter API</description>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -44,7 +44,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -43,18 +43,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-core</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-core</name>
     <description>A Java library for the Twitter API</description>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-core</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>

--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpClientImpl.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpClientImpl.java
@@ -124,11 +124,17 @@ class HttpClientImpl extends HttpClientBase implements HttpResponseCode, java.io
                             }
                             write(out, boundary + "--\r\n");
                             write(out, "\r\n");
-
                         } else {
-                            con.setRequestProperty("Content-Type",
-                                    "application/x-www-form-urlencoded");
-                            String postParam = HttpParameter.encodeParameters(req.getParameters());
+                            String postParam;
+                            if (HttpParameter.containsJson(req.getParameters())) {
+                                con.setRequestProperty("Content-Type",
+                                        "application/json");
+                                postParam = req.getParameters()[0].getJsonObject().toString();
+                            } else {
+                                con.setRequestProperty("Content-Type",
+                                        "application/x-www-form-urlencoded");
+                                postParam = HttpParameter.encodeParameters(req.getParameters());
+                            }
                             logger.debug("Post Params: ", postParam);
                             byte[] bytes = postParam.getBytes("UTF-8");
                             con.setRequestProperty("Content-Length",

--- a/twitter4j-core/src/internal-http/java/twitter4j/HttpParameter.java
+++ b/twitter4j-core/src/internal-http/java/twitter4j/HttpParameter.java
@@ -33,12 +33,17 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
     private static final long serialVersionUID = 4046908449190454692L;
     private String name = null;
     private String value = null;
+    private JSONObject jsonObject = null;
     private File file = null;
     private InputStream fileBody = null;
 
     public HttpParameter(String name, String value) {
         this.name = name;
         this.value = value;
+    }
+
+    public HttpParameter(JSONObject jsonObject) {
+        this.jsonObject = jsonObject;
     }
 
     public HttpParameter(String name, File file) {
@@ -80,6 +85,10 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
         return value;
     }
 
+    public JSONObject getJsonObject() {
+        return jsonObject;
+    }
+
     public File getFile() {
         return file;
     }
@@ -90,6 +99,10 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
 
     public boolean isFile() {
         return file != null;
+    }
+
+    public boolean isJson() {
+        return jsonObject != null;
     }
 
     public boolean hasFileBody() {
@@ -142,19 +155,20 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof HttpParameter)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
 
         HttpParameter that = (HttpParameter) o;
 
-        if (file != null ? !file.equals(that.file) : that.file != null)
-            return false;
-        if (fileBody != null ? !fileBody.equals(that.fileBody) : that.fileBody != null)
-            return false;
-        if (!name.equals(that.name)) return false;
-        if (value != null ? !value.equals(that.value) : that.value != null)
-            return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (value != null ? !value.equals(that.value) : that.value != null) return false;
+        if (jsonObject != null ? !jsonObject.equals(that.jsonObject) : that.jsonObject != null) return false;
+        if (file != null ? !file.equals(that.file) : that.file != null) return false;
+        return fileBody != null ? fileBody.equals(that.fileBody) : that.fileBody == null;
 
-        return true;
+    }
+
+    public static boolean containsJson(HttpParameter[] params) {
+        return params.length == 1 && params[0].isJson();
     }
 
     public static boolean containsFile(HttpParameter[] params) {
@@ -204,8 +218,9 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
 
     @Override
     public int hashCode() {
-        int result = name.hashCode();
+        int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (jsonObject != null ? jsonObject.hashCode() : 0);
         result = 31 * result + (file != null ? file.hashCode() : 0);
         result = 31 * result + (fileBody != null ? fileBody.hashCode() : 0);
         return result;
@@ -213,9 +228,10 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
 
     @Override
     public String toString() {
-        return "PostParameter{" +
+        return "HttpParameter{" +
                 "name='" + name + '\'' +
                 ", value='" + value + '\'' +
+                ", jsonObject=" + jsonObject +
                 ", file=" + file +
                 ", fileBody=" + fileBody +
                 '}';
@@ -223,10 +239,14 @@ public final class HttpParameter implements Comparable<HttpParameter>, java.io.S
 
     @Override
     public int compareTo(HttpParameter o) {
-        int compared;
-        compared = name.compareTo(o.name);
+        int compared = 0;
+        if (name != null) {
+            compared = name.compareTo(o.name);
+        }
         if (0 == compared) {
-            compared = value.compareTo(o.value);
+            if (value != null) {
+                compared = value.compareTo(o.value);
+            }
         }
         return compared;
     }

--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventJSONImpl.java
@@ -1,0 +1,202 @@
+package twitter4j;
+
+import twitter4j.conf.Configuration;
+
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+/*package*/ final class DirectMessageEventJSONImpl extends TwitterResponseImpl implements DirectMessageEvent, java.io.Serializable {
+    private static final long serialVersionUID = -7387326608536231792L;
+    private String type;
+    private long id;
+    private Date createdTimestamp;
+    private long recipientId;
+    private long senderId;
+    private String text;
+    private UserMentionEntity[] userMentionEntities;
+    private URLEntity[] urlEntities;
+    private HashtagEntity[] hashtagEntities;
+    private MediaEntity[] mediaEntities;
+    private SymbolEntity[] symbolEntities;
+
+
+    /*package*/DirectMessageEventJSONImpl(HttpResponse res, Configuration conf) throws TwitterException {
+        super(res);
+        JSONObject json = res.asJSONObject();
+        try {
+            init(json.getJSONObject("event"));
+            if (conf.isJSONStoreEnabled()) {
+                TwitterObjectFactory.clearThreadLocalMap();
+                TwitterObjectFactory.registerJSONObject(this, json);
+            }
+        } catch (JSONException jsone) {
+            throw new TwitterException(jsone);
+        }
+    }
+
+    /*package*/DirectMessageEventJSONImpl(JSONObject json) throws TwitterException {
+        init(json);
+    }
+
+    private void init(JSONObject event) throws TwitterException {
+
+        try {
+            type = ParseUtil.getUnescapedString("type", event);
+            id = ParseUtil.getLong("id", event);
+            createdTimestamp = new Date(event.getLong("created_timestamp"));
+
+            final JSONObject messageCreate = event.getJSONObject("message_create");
+            recipientId = ParseUtil.getLong("recipient_id", messageCreate.getJSONObject("target"));
+            senderId = ParseUtil.getLong("sender_id", messageCreate);
+
+            final JSONObject messageData = messageCreate.getJSONObject("message_data");
+            text = ParseUtil.getUnescapedString("text", messageData);
+
+            if (!messageData.isNull("entities")) {
+                JSONObject entities = messageData.getJSONObject("entities");
+                userMentionEntities = EntitiesParseUtil.getUserMentions(entities);
+                urlEntities = EntitiesParseUtil.getUrls(entities);
+                hashtagEntities = EntitiesParseUtil.getHashtags(entities);
+                symbolEntities = EntitiesParseUtil.getSymbols(entities);
+            }
+            userMentionEntities = userMentionEntities == null ? new UserMentionEntity[0] : userMentionEntities;
+            urlEntities = urlEntities == null ? new URLEntity[0] : urlEntities;
+            hashtagEntities = hashtagEntities == null ? new HashtagEntity[0] : hashtagEntities;
+            symbolEntities = symbolEntities == null ? new SymbolEntity[0] : symbolEntities;
+
+            if (!messageData.isNull("attachment")) {
+                JSONObject attachment = messageData.getJSONObject("attachment");
+                // force parsing "type" as "media"
+                if (!attachment.isNull("media")) {
+                    mediaEntities = new MediaEntity[1];
+                    mediaEntities[0] = new MediaEntityJSONImpl(attachment.getJSONObject("media"));
+                }
+            }
+            mediaEntities = mediaEntities == null ? new MediaEntity[0] : mediaEntities;
+
+            text = HTMLEntity.unescapeAndSlideEntityIncdices(messageData.getString("text"), userMentionEntities,
+                    urlEntities, hashtagEntities, mediaEntities);
+        } catch (JSONException jsone) {
+            throw new TwitterException(jsone);
+        }
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public long getId() {
+        return id;
+    }
+
+    @Override
+    public Date getCreatedTimestamp() {
+        return createdTimestamp;
+    }
+
+    @Override
+    public long getRecipientId() {
+        return recipientId;
+    }
+
+    @Override
+    public long getSenderId() {
+        return senderId;
+    }
+
+    @Override
+    public String getText() {
+        return text;
+    }
+
+    @Override
+    public UserMentionEntity[] getUserMentionEntities() {
+        return userMentionEntities;
+    }
+
+    @Override
+    public URLEntity[] getUrlEntities() {
+        return urlEntities;
+    }
+
+    @Override
+    public HashtagEntity[] getHashtagEntities() {
+        return hashtagEntities;
+    }
+
+    @Override
+    public MediaEntity[] getMediaEntities() {
+        return mediaEntities;
+    }
+
+    @Override
+    public SymbolEntity[] getSymbolEntities() {
+        return symbolEntities;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DirectMessageEventJSONImpl that = (DirectMessageEventJSONImpl) o;
+
+        if (id != that.id) return false;
+        if (recipientId != that.recipientId) return false;
+        if (senderId != that.senderId) return false;
+        if (type != null ? !type.equals(that.type) : that.type != null) return false;
+        if (createdTimestamp != null ? !createdTimestamp.equals(that.createdTimestamp) : that.createdTimestamp != null)
+            return false;
+        if (text != null ? !text.equals(that.text) : that.text != null) return false;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(userMentionEntities, that.userMentionEntities)) return false;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(urlEntities, that.urlEntities)) return false;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(hashtagEntities, that.hashtagEntities)) return false;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        if (!Arrays.equals(mediaEntities, that.mediaEntities)) return false;
+        // Probably incorrect - comparing Object[] arrays with Arrays.equals
+        return Arrays.equals(symbolEntities, that.symbolEntities);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (int) (id ^ (id >>> 32));
+        result = 31 * result + (createdTimestamp != null ? createdTimestamp.hashCode() : 0);
+        result = 31 * result + (int) (recipientId ^ (recipientId >>> 32));
+        result = 31 * result + (int) (senderId ^ (senderId >>> 32));
+        result = 31 * result + (text != null ? text.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(userMentionEntities);
+        result = 31 * result + Arrays.hashCode(urlEntities);
+        result = 31 * result + Arrays.hashCode(hashtagEntities);
+        result = 31 * result + Arrays.hashCode(mediaEntities);
+        result = 31 * result + Arrays.hashCode(symbolEntities);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DirectMessageEventJSONImpl{" +
+                "type='" + type + '\'' +
+                ", id=" + id +
+                ", createdTimestamp=" + createdTimestamp +
+                ", recipientId=" + recipientId +
+                ", senderId=" + senderId +
+                ", text='" + text + '\'' +
+                ", userMentionEntities=" + Arrays.toString(userMentionEntities) +
+                ", urlEntities=" + Arrays.toString(urlEntities) +
+                ", hashtagEntities=" + Arrays.toString(hashtagEntities) +
+                ", mediaEntities=" + Arrays.toString(mediaEntities) +
+                ", symbolEntities=" + Arrays.toString(symbolEntities) +
+                '}';
+    }
+}

--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventListImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageEventListImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j;
+
+/**
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+class DirectMessageEventListImpl extends ResponseListImpl<DirectMessageEvent> implements DirectMessageEventList {
+    private static final long serialVersionUID = 8150060768287194508L;
+    private final String nextCursor;
+
+    DirectMessageEventListImpl(RateLimitStatus rateLimitStatus, int accessLevel) {
+        super(rateLimitStatus, accessLevel);
+        nextCursor = null;
+    }
+
+    DirectMessageEventListImpl(int size, JSONObject json, HttpResponse res) {
+        super(size, res);
+        this.nextCursor = ParseUtil.getRawString("next_cursor", json);
+    }
+
+    @Override
+    public String getNextCursor() {
+        return nextCursor;
+    }
+
+}

--- a/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/DirectMessageJSONImpl.java
@@ -68,52 +68,11 @@ import java.util.Date;
             recipient = new UserJSONImpl(json.getJSONObject("recipient"));
             if (!json.isNull("entities")) {
                 JSONObject entities = json.getJSONObject("entities");
-                int len;
-                if (!entities.isNull("user_mentions")) {
-                    JSONArray userMentionsArray = entities.getJSONArray("user_mentions");
-                    len = userMentionsArray.length();
-                    userMentionEntities = new UserMentionEntity[len];
-                    for (int i = 0; i < len; i++) {
-                        userMentionEntities[i] = new UserMentionEntityJSONImpl(userMentionsArray.getJSONObject(i));
-                    }
-
-                }
-                if (!entities.isNull("urls")) {
-                    JSONArray urlsArray = entities.getJSONArray("urls");
-                    len = urlsArray.length();
-                    urlEntities = new URLEntity[len];
-                    for (int i = 0; i < len; i++) {
-                        urlEntities[i] = new URLEntityJSONImpl(urlsArray.getJSONObject(i));
-                    }
-                }
-
-                if (!entities.isNull("hashtags")) {
-                    JSONArray hashtagsArray = entities.getJSONArray("hashtags");
-                    len = hashtagsArray.length();
-                    hashtagEntities = new HashtagEntity[len];
-                    for (int i = 0; i < len; i++) {
-                        hashtagEntities[i] = new HashtagEntityJSONImpl(hashtagsArray.getJSONObject(i));
-                    }
-                }
-
-                if (!entities.isNull("symbols")) {
-                    JSONArray symbolsArray = entities.getJSONArray("symbols");
-                    len = symbolsArray.length();
-                    symbolEntities = new SymbolEntity[len];
-                    for (int i = 0; i < len; i++) {
-                        // HashtagEntityJSONImpl also implements SymbolEntities
-                        symbolEntities[i] = new HashtagEntityJSONImpl(symbolsArray.getJSONObject(i));
-                    }
-                }
-
-                if (!entities.isNull("media")) {
-                    JSONArray mediaArray = entities.getJSONArray("media");
-                    len = mediaArray.length();
-                    mediaEntities = new MediaEntity[len];
-                    for (int i = 0; i < len; i++) {
-                        mediaEntities[i] = new MediaEntityJSONImpl(mediaArray.getJSONObject(i));
-                    }
-                }
+                userMentionEntities = EntitiesParseUtil.getUserMentions(entities);
+                urlEntities = EntitiesParseUtil.getUrls(entities);
+                hashtagEntities = EntitiesParseUtil.getHashtags(entities);
+                symbolEntities = EntitiesParseUtil.getSymbols(entities);
+                mediaEntities = EntitiesParseUtil.getMedia(entities);
             }
             userMentionEntities = userMentionEntities == null ? new UserMentionEntity[0] : userMentionEntities;
             urlEntities = urlEntities == null ? new URLEntity[0] : urlEntities;
@@ -213,6 +172,33 @@ import java.util.Date;
             for (int i = 0; i < size; i++) {
                 JSONObject json = list.getJSONObject(i);
                 DirectMessage directMessage = new DirectMessageJSONImpl(json);
+                directMessages.add(directMessage);
+                if (conf.isJSONStoreEnabled()) {
+                    TwitterObjectFactory.registerJSONObject(directMessage, json);
+                }
+            }
+            if (conf.isJSONStoreEnabled()) {
+                TwitterObjectFactory.registerJSONObject(directMessages, list);
+            }
+            return directMessages;
+        } catch (JSONException jsone) {
+            throw new TwitterException(jsone);
+        }
+    }
+
+    /*package*/
+    static DirectMessageEventList createDirectMessageEventList(HttpResponse res, Configuration conf) throws TwitterException {
+        try {
+            if (conf.isJSONStoreEnabled()) {
+                TwitterObjectFactory.clearThreadLocalMap();
+            }
+            JSONObject jsonObject = res.asJSONObject();
+            JSONArray list = jsonObject.getJSONArray("events");
+            int size = list.length();
+            DirectMessageEventList directMessages = new DirectMessageEventListImpl(size, jsonObject, res);
+            for (int i = 0; i < size; i++) {
+                JSONObject json = list.getJSONObject(i);
+                DirectMessageEvent directMessage = new DirectMessageEventJSONImpl(json);
                 directMessages.add(directMessage);
                 if (conf.isJSONStoreEnabled()) {
                     TwitterObjectFactory.registerJSONObject(directMessage, json);

--- a/twitter4j-core/src/internal-json/java/twitter4j/JSONImplFactory.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/JSONImplFactory.java
@@ -193,6 +193,16 @@ class JSONImplFactory implements ObjectFactory {
     }
 
     @Override
+    public DirectMessageEvent createDirectMessageEvent(HttpResponse res) throws TwitterException {
+        return new DirectMessageEventJSONImpl(res, conf);
+    }
+
+    @Override
+    public DirectMessageEventList createDirectMessageEventList(HttpResponse res) throws TwitterException {
+        return DirectMessageJSONImpl.createDirectMessageEventList(res, conf);
+    }
+
+    @Override
     public Relationship createRelationship(HttpResponse res) throws TwitterException {
         return new RelationshipJSONImpl(res, conf);
     }

--- a/twitter4j-core/src/internal-json/java/twitter4j/ObjectFactory.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/ObjectFactory.java
@@ -65,6 +65,10 @@ interface ObjectFactory extends java.io.Serializable {
 
     ResponseList<DirectMessage> createDirectMessageList(HttpResponse res) throws TwitterException;
 
+    DirectMessageEvent createDirectMessageEvent(HttpResponse res) throws TwitterException;
+
+    DirectMessageEventList createDirectMessageEventList(HttpResponse res) throws TwitterException;
+
     Relationship createRelationship(HttpResponse res) throws TwitterException;
 
     ResponseList<Friendship> createFriendshipList(HttpResponse res) throws TwitterException;

--- a/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
+++ b/twitter4j-core/src/internal-json/java/twitter4j/StatusJSONImpl.java
@@ -197,51 +197,11 @@ import static twitter4j.ParseUtil.getDate;
     private void collectEntities(JSONObject json) throws JSONException, TwitterException {
         if (!json.isNull("entities")) {
             JSONObject entities = json.getJSONObject("entities");
-            int len;
-            if (!entities.isNull("user_mentions")) {
-                JSONArray userMentionsArray = entities.getJSONArray("user_mentions");
-                len = userMentionsArray.length();
-                userMentionEntities = new UserMentionEntity[len];
-                for (int i = 0; i < len; i++) {
-                    userMentionEntities[i] = new UserMentionEntityJSONImpl(userMentionsArray.getJSONObject(i));
-                }
-            }
-            if (!entities.isNull("urls")) {
-                JSONArray urlsArray = entities.getJSONArray("urls");
-                len = urlsArray.length();
-                urlEntities = new URLEntity[len];
-                for (int i = 0; i < len; i++) {
-                    urlEntities[i] = new URLEntityJSONImpl(urlsArray.getJSONObject(i));
-                }
-            }
-
-            if (!entities.isNull("hashtags")) {
-                JSONArray hashtagsArray = entities.getJSONArray("hashtags");
-                len = hashtagsArray.length();
-                hashtagEntities = new HashtagEntity[len];
-                for (int i = 0; i < len; i++) {
-                    hashtagEntities[i] = new HashtagEntityJSONImpl(hashtagsArray.getJSONObject(i));
-                }
-            }
-
-            if (!entities.isNull("symbols")) {
-                JSONArray hashtagsArray = entities.getJSONArray("symbols");
-                len = hashtagsArray.length();
-                symbolEntities = new SymbolEntity[len];
-                for (int i = 0; i < len; i++) {
-                    // HashtagEntityJSONImpl also implements SymbolEntities
-                    symbolEntities[i] = new HashtagEntityJSONImpl(hashtagsArray.getJSONObject(i));
-                }
-            }
-
-            if (!entities.isNull("media")) {
-                JSONArray mediaArray = entities.getJSONArray("media");
-                len = mediaArray.length();
-                mediaEntities = new MediaEntity[len];
-                for (int i = 0; i < len; i++) {
-                    mediaEntities[i] = new MediaEntityJSONImpl(mediaArray.getJSONObject(i));
-                }
-            }
+            userMentionEntities = EntitiesParseUtil.getUserMentions(entities);
+            urlEntities = EntitiesParseUtil.getUrls(entities);
+            hashtagEntities = EntitiesParseUtil.getHashtags(entities);
+            symbolEntities = EntitiesParseUtil.getSymbols(entities);
+            mediaEntities = EntitiesParseUtil.getMedia(entities);
         }
     }
 

--- a/twitter4j-core/src/main/java/twitter4j/DirectMessageEvent.java
+++ b/twitter4j-core/src/main/java/twitter4j/DirectMessageEvent.java
@@ -1,0 +1,32 @@
+package twitter4j;
+
+import java.util.Date;
+
+/**
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+public interface DirectMessageEvent extends TwitterResponse {
+
+    String getType();
+
+    long getId();
+
+    Date getCreatedTimestamp();
+
+    long getRecipientId();
+
+    long getSenderId();
+
+    String getText();
+
+    UserMentionEntity[] getUserMentionEntities();
+
+    URLEntity[] getUrlEntities();
+
+    HashtagEntity[] getHashtagEntities();
+
+    MediaEntity[] getMediaEntities();
+
+    SymbolEntity[] getSymbolEntities();
+}

--- a/twitter4j-core/src/main/java/twitter4j/DirectMessageEventList.java
+++ b/twitter4j-core/src/main/java/twitter4j/DirectMessageEventList.java
@@ -1,0 +1,14 @@
+package twitter4j;
+
+/**
+ * List of {@link DirectMessageEvent}
+ *
+ * like string cursor version of {@link PagableResponseList}
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+public interface DirectMessageEventList extends ResponseList<DirectMessageEvent> {
+
+    String getNextCursor();
+}

--- a/twitter4j-core/src/main/java/twitter4j/EntitiesParseUtil.java
+++ b/twitter4j-core/src/main/java/twitter4j/EntitiesParseUtil.java
@@ -1,0 +1,75 @@
+package twitter4j;
+
+/*package*/ class EntitiesParseUtil {
+
+    /*package*/ static UserMentionEntity[] getUserMentions(JSONObject entities) throws JSONException, TwitterException {
+        if (!entities.isNull("user_mentions")) {
+            JSONArray userMentionsArray = entities.getJSONArray("user_mentions");
+            int len = userMentionsArray.length();
+            UserMentionEntity[] userMentionEntities = new UserMentionEntity[len];
+            for (int i = 0; i < len; i++) {
+                userMentionEntities[i] = new UserMentionEntityJSONImpl(userMentionsArray.getJSONObject(i));
+            }
+            return userMentionEntities;
+        } else {
+            return null;
+        }
+    }
+
+    /*package*/ static URLEntity[] getUrls(JSONObject entities) throws JSONException, TwitterException {
+        if (!entities.isNull("urls")) {
+            JSONArray urlsArray = entities.getJSONArray("urls");
+            int len = urlsArray.length();
+            URLEntity[] urlEntities = new URLEntity[len];
+            for (int i = 0; i < len; i++) {
+                urlEntities[i] = new URLEntityJSONImpl(urlsArray.getJSONObject(i));
+            }
+            return urlEntities;
+        } else {
+            return null;
+        }
+    }
+
+    /*package*/ static HashtagEntity[] getHashtags(JSONObject entities) throws JSONException, TwitterException {
+        if (!entities.isNull("hashtags")) {
+            JSONArray hashtagsArray = entities.getJSONArray("hashtags");
+            int len = hashtagsArray.length();
+            HashtagEntity[] hashtagEntities = new HashtagEntity[len];
+            for (int i = 0; i < len; i++) {
+                hashtagEntities[i] = new HashtagEntityJSONImpl(hashtagsArray.getJSONObject(i));
+            }
+            return hashtagEntities;
+        } else {
+            return null;
+        }
+    }
+
+    /*package*/ static SymbolEntity[] getSymbols(JSONObject entities) throws JSONException, TwitterException {
+        if (!entities.isNull("symbols")) {
+            JSONArray symbolsArray = entities.getJSONArray("symbols");
+            int len = symbolsArray.length();
+            SymbolEntity[] symbolEntities = new SymbolEntity[len];
+            for (int i = 0; i < len; i++) {
+                // HashtagEntityJSONImpl also implements SymbolEntities
+                symbolEntities[i] = new HashtagEntityJSONImpl(symbolsArray.getJSONObject(i));
+            }
+            return symbolEntities;
+        } else {
+            return null;
+        }
+    }
+
+    /*package*/ static MediaEntity[] getMedia(JSONObject entities) throws JSONException, TwitterException {
+        if (!entities.isNull("media")) {
+            JSONArray mediaArray = entities.getJSONArray("media");
+            int len = mediaArray.length();
+            MediaEntity[] mediaEntities = new MediaEntity[len];
+            for (int i = 0; i < len; i++) {
+                mediaEntities[i] = new MediaEntityJSONImpl(mediaArray.getJSONObject(i));
+            }
+            return mediaEntities;
+        } else {
+            return null;
+        }
+    }
+}

--- a/twitter4j-core/src/main/java/twitter4j/MessageData.java
+++ b/twitter4j-core/src/main/java/twitter4j/MessageData.java
@@ -1,0 +1,50 @@
+package twitter4j;
+
+/**
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ * @since Twitter4J 4.0.7
+ */
+public final class MessageData {
+
+    private final long recipientId;
+    private final String text;
+    private String type = null;
+    private long mediaId = -1;
+
+    public MessageData(long recipientId, String text) {
+        this.recipientId = recipientId;
+        this.text = text;
+    }
+
+    public MessageData setMediaId(long mediaId) {
+        this.type = "media";
+        this.mediaId = mediaId;
+        return this;
+    }
+
+    public JSONObject createMessageCreateJsonObject() throws JSONException {
+
+        final JSONObject json = new JSONObject();
+
+        final JSONObject target = new JSONObject();
+        target.put("recipient_id", this.recipientId);
+        json.put("target", target);
+
+        final JSONObject messageData = new JSONObject();
+        messageData.put("text", this.text);
+        if (this.type != null && this.mediaId != -1) {
+            final JSONObject attachment = new JSONObject();
+            attachment.put("type", this.type);
+            if (type.equals("media")) {
+                final JSONObject media = new JSONObject();
+                media.put("id", this.mediaId);
+                attachment.put("media", media);
+            }
+            messageData.put("attachment", attachment);
+        }
+        json.put("message_data", messageData);
+
+        return json;
+    }
+
+}

--- a/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
+++ b/twitter4j-core/src/main/java/twitter4j/TwitterImpl.java
@@ -284,6 +284,19 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
+    public DirectMessageEventList getDirectMessageEvents(int count) throws TwitterException {
+        return factory.createDirectMessageEventList(get(conf.getRestBaseURL() + "direct_messages/events/list.json"
+                , new HttpParameter("count", count) ));
+    }
+
+    @Override
+    public DirectMessageEventList getDirectMessageEvents(int count, String cursor) throws TwitterException {
+        return factory.createDirectMessageEventList(get(conf.getRestBaseURL() + "direct_messages/events/list.json"
+                , new HttpParameter("count", count)
+                , new HttpParameter("cursor", cursor)));
+    }
+
+    @Override
     public ResponseList<DirectMessage> getSentDirectMessages() throws TwitterException {
         return factory.createDirectMessageList(get(conf.getRestBaseURL() + "direct_messages/sent.json?full_text=true"));
     }
@@ -302,10 +315,35 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
     }
 
     @Override
-    public DirectMessage destroyDirectMessage(long id) throws
-        TwitterException {
+    public DirectMessageEvent showDirectMessageEvent(long id) throws TwitterException {
+        return factory.createDirectMessageEvent(get(conf.getRestBaseURL() + "direct_messages/events/show.json?id=" + id));
+    }
+
+    @Override
+    public DirectMessage destroyDirectMessage(long id) throws TwitterException {
         return factory.createDirectMessage(post(conf.getRestBaseURL() + "direct_messages/destroy.json?id=" + id
             + "&full_text=true"));
+    }
+
+    @Override
+    public void destroyDirectMessageEvent(long id) throws TwitterException {
+        ensureAuthorizationEnabled();
+        http.delete(conf.getRestBaseURL() + "direct_messages/events/destroy.json?id=" + id, null, auth, null);
+    }
+
+    @Override
+    public DirectMessageEvent createMessage(MessageData messageData)
+            throws TwitterException {
+        try {
+            final JSONObject json = new JSONObject();
+            final JSONObject event = new JSONObject();
+            event.put("type", "message_create");
+            event.put("message_create", messageData.createMessageCreateJsonObject());
+            json.put("event", event);
+            return factory.createDirectMessageEvent(post(conf.getRestBaseURL() + "direct_messages/events/new.json", json));
+        } catch (JSONException e) {
+            throw new TwitterException(e);
+        }
     }
 
     @Override
@@ -1831,6 +1869,24 @@ class TwitterImpl extends TwitterBaseImpl implements Twitter {
             long start = System.currentTimeMillis();
             try {
                 response = http.post(url, mergeImplicitParams(params), auth, this);
+            } finally {
+                long elapsedTime = System.currentTimeMillis() - start;
+                TwitterAPIMonitor.getInstance().methodCalled(url, elapsedTime, isOk(response));
+            }
+            return response;
+        }
+    }
+
+    private HttpResponse post(String url, JSONObject json) throws TwitterException {
+        ensureAuthorizationEnabled();
+        if (!conf.isMBeanEnabled()) {
+            return http.post(url, new HttpParameter[]{new HttpParameter(json)}, auth, this);
+        } else {
+            // intercept HTTP call for monitoring purposes
+            HttpResponse response = null;
+            long start = System.currentTimeMillis();
+            try {
+                response = http.post(url, new HttpParameter[]{new HttpParameter(json)}, auth, this);
             } finally {
                 long elapsedTime = System.currentTimeMillis() - start;
                 TwitterAPIMonitor.getInstance().methodCalled(url, elapsedTime, isOk(response));

--- a/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
+++ b/twitter4j-core/src/main/java/twitter4j/api/DirectMessagesResources.java
@@ -17,6 +17,9 @@
 package twitter4j.api;
 
 import twitter4j.DirectMessage;
+import twitter4j.DirectMessageEvent;
+import twitter4j.DirectMessageEventList;
+import twitter4j.MessageData;
 import twitter4j.Paging;
 import twitter4j.ResponseList;
 import twitter4j.TwitterException;
@@ -34,6 +37,7 @@ public interface DirectMessagesResources {
      * @return List
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages">GET direct_messages | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getDirectMessages()
         throws TwitterException;
@@ -46,6 +50,7 @@ public interface DirectMessagesResources {
      * @return List
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages">GET direct_messages | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getDirectMessages(Paging paging)
         throws TwitterException;
@@ -57,6 +62,7 @@ public interface DirectMessagesResources {
      * @return List
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages/sent">GET direct_messages/sent | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getSentDirectMessages()
         throws TwitterException;
@@ -70,9 +76,35 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/get/direct_messages/sent">GET direct_messages/sent | Twitter Developers</a>
      * @since Twitter4J 2.0.1
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     ResponseList<DirectMessage> getSentDirectMessages(Paging paging)
         throws TwitterException;
+
+    /**
+     * Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/list.json
+     *
+     * @param count Max number of events to be returned. 20 default. 50 max.
+     * @return List
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events.html" title="GET direct_messages/events/list — Twitter Developers">GET direct_messages/events/list — Twitter Developers</a>
+     */
+    DirectMessageEventList getDirectMessageEvents(int count)
+            throws TwitterException;
+
+    /**
+     * Returns all Direct Message events (both sent and received) within the last 30 days. Sorted in reverse-chronological order.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/list.json
+     *
+     * @param count Max number of events to be returned. 20 default. 50 max.
+     * @param cursor For paging through result sets greater than 1 page, use the “next_cursor” property from the previous request.
+     * @return List
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events.html" title="GET direct_messages/events/list — Twitter Developers">GET direct_messages/events/list — Twitter Developers</a>
+     */
+    DirectMessageEventList getDirectMessageEvents(int count, String cursor)
+            throws TwitterException;
 
     /**
      * Returns a single direct message, specified by an id parameter.
@@ -84,8 +116,22 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="http://groups.google.com/group/twitter-api-announce/msg/34909da7c399169e">#newtwitter and the API - Twitter API Announcements | Google Group</a>
      * @since Twitter4J 2.1.9
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage showDirectMessage(long id) throws TwitterException;
+
+    /**
+     * Returns a single Direct Message event by the given id.
+     * <br>This method has not been finalized and the interface is subject to change in incompatible ways.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/show.json
+     *
+     * @param id message id
+     * @return DirectMessageEvent
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-event.html" title="GET direct_messages/events/show — Twitter Developers">GET direct_messages/events/show — Twitter Developers</a>
+     * @since Twitter4J 4.0.x
+     */
+    DirectMessageEvent showDirectMessageEvent(long id) throws TwitterException;
 
     /**
      * Destroys the direct message specified in the required ID parameter.  The authenticating user must be the recipient of the specified direct message.
@@ -96,21 +142,49 @@ public interface DirectMessagesResources {
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/direct_messages/destroy/:id">POST direct_messages/destroy/:id | Twitter Developers</a>
      * @since Twitter4J 2.0.1
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage destroyDirectMessage(long id)
         throws TwitterException;
+
+    /**
+     * Deletes the direct message specified in the required ID parameter.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/events/destroy.json
+     *
+     * @param The id of the Direct Message event that should be deleted.
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event.html" title="DELETE direct_messages/events/destroy — Twitter Developers">DELETE direct_messages/events/destroy — Twitter Developers</a>
+     * @since Twitter4J 4.0.x
+     */
+    void destroyDirectMessageEvent(long id)
+            throws TwitterException;
 
     /**
      * Sends a new direct message to the specified user from the authenticating user.  Requires both the user and text parameters below.
      * The text will be trimmed if the length of the text is exceeding 140 characters.
      * <br>This method calls https://api.twitter.com/1.1/direct_messages/new
      *
-     * @param userId the screen name of the user to whom send the direct message
+     * @param messageData The Message Data Object defining the content to deliver to the reciepient.
+     * @return DirectMessageEvent
+     * @throws TwitterException when Twitter service or network is unavailable
+     * @see <a href="https://dev.twitter.com/rest/reference/post/direct_messages/events/new">POST direct_messages/events/new (message_create) — Twitter Developers</a>
+     * @since Twitter4j 4.0.7
+     */
+    DirectMessageEvent createMessage(MessageData messageData)
+            throws TwitterException;
+
+    /**
+     * Sends a new direct message to the specified user from the authenticating user.  Requires both the user and text parameters below.
+     * The text will be trimmed if the length of the text is exceeding 140 characters.
+     * <br>This method calls https://api.twitter.com/1.1/direct_messages/new
+     *
+     * @param userId the user id of the user to whom send the direct message
      * @param text   The text of your direct message.
      * @return DirectMessage
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/direct_messages/new">POST direct_messages/new | Twitter Developers</a>
      * @since Twitter4j 2.1.0
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage sendDirectMessage(long userId, String text)
         throws TwitterException;
@@ -125,6 +199,7 @@ public interface DirectMessagesResources {
      * @return DirectMessage
      * @throws TwitterException when Twitter service or network is unavailable
      * @see <a href="https://dev.twitter.com/docs/api/1.1/post/direct_messages/new">POST direct_messages/new | Twitter Developers</a>
+     * @deprecated This endpoint will be deprecated and non-functional on June 19, 2018.
      */
     DirectMessage sendDirectMessage(String screenName, String text)
         throws TwitterException;

--- a/twitter4j-core/src/main/java/twitter4j/auth/OAuthAuthorization.java
+++ b/twitter4j-core/src/main/java/twitter4j/auth/OAuthAuthorization.java
@@ -378,11 +378,8 @@ public class OAuthAuthorization implements Authorization, java.io.Serializable, 
     public static String encodeParameters(List<HttpParameter> httpParams, String splitter, boolean quot) {
         StringBuilder buf = new StringBuilder();
         for (HttpParameter param : httpParams) {
-            if (!param.isFile()) {
+            if (!param.isFile() && !param.isJson()) {
                 if (buf.length() != 0) {
-                    if (quot) {
-                        buf.append("\"");
-                    }
                     buf.append(splitter);
                 }
                 buf.append(HttpParameter.encode(param.getName())).append("=");
@@ -390,6 +387,9 @@ public class OAuthAuthorization implements Authorization, java.io.Serializable, 
                     buf.append("\"");
                 }
                 buf.append(HttpParameter.encode(param.getValue()));
+                if (quot) {
+                    buf.append("\"");
+                }
             }
         }
         if (buf.length() != 0) {

--- a/twitter4j-examples/bin/directmessage/createMessage.cmd
+++ b/twitter4j-examples/bin/directmessage/createMessage.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.CreateMessage %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/createMessage.sh
+++ b/twitter4j-examples/bin/directmessage/createMessage.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.CreateMessage"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.cmd
+++ b/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.DestroyDirectMessageEvent %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.sh
+++ b/twitter4j-examples/bin/directmessage/destroyDirectMessageEvent.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.DestroyDirectMessageEvent"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/bin/directmessage/getDirectMessageEvents.cmd
+++ b/twitter4j-examples/bin/directmessage/getDirectMessageEvents.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.GetDirectMessageEvents %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/getDirectMessageEvents.sh
+++ b/twitter4j-examples/bin/directmessage/getDirectMessageEvents.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.GetDirectMessageEvents"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/bin/directmessage/showDirectMessageEvent.cmd
+++ b/twitter4j-examples/bin/directmessage/showDirectMessageEvent.cmd
@@ -1,0 +1,9 @@
+echo off
+SETLOCAL enabledelayedexpansion
+cd ..
+call setEnv.cmd
+
+echo on
+"%JAVA_HOME%\bin\java" %MEM_ARGS% -classpath "%CLASSPATH%" twitter4j.examples.directmessage.ShowDirectMessageEvent %*
+
+ENDLOCAL

--- a/twitter4j-examples/bin/directmessage/showDirectMessageEvent.sh
+++ b/twitter4j-examples/bin/directmessage/showDirectMessageEvent.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ..
+. ./setEnv.sh
+RUN_CMD="$JAVA_HOME/bin/java $MEM_ARGS -cp $CLASSPATH twitter4j.examples.directmessage.ShowDirectMessageEvent"
+echo $RUN_CMD ${1+"$@"}
+exec $RUN_CMD ${1+"$@"}

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -44,7 +44,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-examples</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
@@ -87,22 +87,22 @@
     </mailingLists>
     <dependencies>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-stream</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-media-support</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-examples</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-examples</name>
     <description>A Java library for the Twitter API</description>
@@ -98,22 +98,22 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-stream</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-media-support</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -43,18 +43,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/CreateMessage.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/CreateMessage.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.*;
+
+/**
+ * Example application that sends a message to specified Twitter-er from specified account.<br>
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public final class CreateMessage {
+    /**
+     * Usage: java twitter4j.examples.directMessage.CreateMessage [recipient screen name] [message]
+     *
+     * @param args String[]
+     */
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.out.println("Usage: java twitter4j.examples.directmessage.CreateMessage [recipient user id] [message]");
+            System.exit(-1);
+        }
+        Twitter twitter = new TwitterFactory().getInstance();
+        try {
+            MessageData messageData = new MessageData(Long.parseLong(args[0]), args[1]);
+            DirectMessageEvent message = twitter.createMessage(messageData);
+            System.out.println("Direct message successfully sent to " + message.getRecipientId());
+            System.out.println(" details:" + message.toString());
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to send a direct message: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/DestroyDirectMessageEvent.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/DestroyDirectMessageEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+/**
+ * Destroys specified message.
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public final class DestroyDirectMessageEvent {
+    /**
+     * Usage: java twitter4j.examples.directmessages.DestroyDirectMessageEvent [message id]
+     *
+     * @param args message
+     */
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: java twitter4j.examples.directmessages.DestroyDirectMessageEvent [message id]");
+            System.exit(-1);
+        }
+        try {
+            Twitter twitter = new TwitterFactory().getInstance();
+            twitter.destroyDirectMessageEvent(Long.parseLong(args[0]));
+            System.out.println("Successfully deleted message [" + args[0] + "].");
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to delete message: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/GetDirectMessageEvents.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/GetDirectMessageEvents.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.DirectMessageEvent;
+import twitter4j.DirectMessageEventList;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+/**
+ * Example application that gets all direct messages via event api.<br>
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public class GetDirectMessageEvents {
+    /**
+     * Usage: java twitter4j.examples.directmessage.GetDirectMessageEvents
+     *
+     * @param args String[]
+     */
+    public static void main(String[] args) {
+        Twitter twitter = new TwitterFactory().getInstance();
+        try {
+            String cursor = null;
+            int count = 20;
+            DirectMessageEventList messages;
+            do {
+                System.out.println("* cursor:" + cursor);
+                messages = cursor == null ? twitter.getDirectMessageEvents(count) : twitter.getDirectMessageEvents(count, cursor);
+                for (DirectMessageEvent message : messages) {
+                    System.out.println("From: " + message.getSenderId() + " id:" + message.getId()
+                            + " [" + message.getCreatedTimestamp() + "]"
+                            + " - " + message.getText());
+                    System.out.println("raw[" + message + "]");
+                }
+                cursor = messages.getNextCursor();
+            } while (messages.size() > 0 && cursor != null);
+            System.out.println("done.");
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to get messages: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/ShowDirectMessageEvent.java
+++ b/twitter4j-examples/src/main/java/twitter4j/examples/directmessage/ShowDirectMessageEvent.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2007 Yusuke Yamamoto
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package twitter4j.examples.directmessage;
+
+import twitter4j.DirectMessageEvent;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+
+/**
+ * Example application that gets a specified direct message via event api.<br>
+ *
+ * @author Hiroaki TAKEUCHI - takke30 at gmail.com
+ */
+public class ShowDirectMessageEvent {
+    /**
+     * Usage: java twitter4j.examples.directmessage.ShowDirectMessageEvent [message id]
+     *
+     * @param args String[]
+     */
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: java twitter4j.examples.directmessage.ShowDirectMessageEvent [message id]");
+            System.exit(-1);
+        }
+        Twitter twitter = new TwitterFactory().getInstance();
+        try {
+            DirectMessageEvent message = twitter.showDirectMessageEvent(Long.parseLong(args[0]));
+            System.out.println("From: @" + message.getSenderId() + " id:" + message.getId() + " - " + message.getText());
+            System.exit(0);
+        } catch (TwitterException te) {
+            te.printStackTrace();
+            System.out.println("Failed to get message: " + te.getMessage());
+            System.exit(-1);
+        }
+    }
+}

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -44,7 +44,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-http2-support</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-http2-support</name>
     <description>A Java library for the Twitter API</description>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -43,18 +43,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-http2-support</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
@@ -87,7 +87,7 @@
     </mailingLists>
     <dependencies>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>

--- a/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
+++ b/twitter4j-http2-support/src/main/java/twitter4j/AlternativeHttpClientImpl.java
@@ -48,6 +48,7 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
 
     private static final MediaType TEXT = MediaType.parse("text/plain; charset=utf-8");
     private static final MediaType FORM_URL_ENCODED = MediaType.parse("application/x-www-form-urlencoded");
+    private static final MediaType APPLICATION_JSON = MediaType.parse("application/json");
 
     private OkHttpClient okHttpClient;
 
@@ -74,8 +75,10 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
         requestBuilder.url(req.getURL()).headers(getHeaders(req));
         switch (req.getMethod()) {
             case HEAD:
-            case DELETE:
             case PUT:
+                break;
+            case DELETE:
+                requestBuilder.delete();
                 break;
             case GET:
                 requestBuilder.get();
@@ -172,6 +175,8 @@ public class AlternativeHttpClientImpl extends HttpClientBase implements HttpRes
                 }
             }
             return multipartBodyBuilder.build();
+        } else if (HttpParameter.containsJson(req.getParameters())) {
+            return RequestBody.create(APPLICATION_JSON, req.getParameters()[0].getJsonObject().toString());
         } else {
             return RequestBody.create(FORM_URL_ENCODED, HttpParameter.encodeParameters(req.getParameters()).getBytes("UTF-8"));
         }

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-media-support</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-media-support</name>
     <description>Twitter4J optional component adds multimedia support
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -45,7 +45,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.twitter4j</groupId>
+    <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-media-support</artifactId>
     <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
@@ -88,7 +88,7 @@
     </mailingLists>
     <dependencies>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -44,18 +44,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -87,12 +87,12 @@
     </mailingLists>
     <dependencies>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
             <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
-            <groupId>org.twitter4j</groupId>
+            <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
             <version>4.0.6-dmevents</version>
             <scope>test</scope>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -44,7 +44,7 @@
     <distributionManagement>
         <repository>
           <id>internal</id>
-          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
+          <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
     <profiles>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-stream</artifactId>
-    <version>4.0.6</version>
+    <version>4.0.6-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-stream</name>
     <description>A Java library for the Twitter API</description>
@@ -98,12 +98,12 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
         </dependency>
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
-            <version>4.0.6</version>
+            <version>4.0.6-dmevents</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -43,18 +43,9 @@
     </issueManagement>
     <distributionManagement>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/
-            </url>
+          <id>internal</id>
+          <url>http://sprout-archiva01.int.sproutsocial.com:8080/archiva/repository/internal/</url>
         </repository>
-        <snapshotRepository>
-            <id>org.twitter4j</id>
-            <name>twitter4j.org Repository</name>
-            <uniqueVersion>false</uniqueVersion>
-            <url>file:${user.home}/maven2/</url>
-        </snapshotRepository>
     </distributionManagement>
     <profiles>
         <profile>


### PR DESCRIPTION
Most of these changes are third party modifications from a [PR](https://github.com/yusuke/twitter4j/pull/260) in the official twitter4j repo.
⚠️  The following is a list of changes I made.
- Updated version to `4.0.6-dmevents`.
- Updated the POMs to set the "group" of the artifacts to `com.sproutsocial.org.twitter4j`.
- Updated `LazyAccountSettings` class with `getAllowDmsFrom()` method implementation (method defined in the interface) so code will compile.  This method was not implemented in previous libraries, version of this class.