### PR TITLE
[Claude] [TOOLCM-4386] Enable dual publishing to CodeArtifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>pom</packaging>
     <name>twitter4j</name>
     <description>A Java library for the Twitter API</description>
@@ -55,6 +55,39 @@
           <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <repositories>
+        <repository>
+            <id>sproutsocial-us-releases</id>
+            <url>https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <profiles>
         <profile>
             <id>release-sign-artifacts</id>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-appengine</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-appengine</name>
     <description>A Java library for the Twitter API</description>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>
@@ -191,6 +191,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-async</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-async</name>
     <description>A Java library for the Twitter API</description>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -175,6 +175,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-core</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-core</name>
     <description>A Java library for the Twitter API</description>
@@ -219,6 +219,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-examples</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-examples</name>
     <description>A Java library for the Twitter API</description>
@@ -89,22 +89,22 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-stream</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-media-support</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -190,6 +190,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-http2-support</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-http2-support</name>
     <description>A Java library for the Twitter API</description>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -195,6 +195,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-media-support</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-media-support</name>
     <description>Twitter4J optional component adds multimedia support
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -171,6 +171,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-stream</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-stream</name>
     <description>A Java library for the Twitter API</description>
@@ -89,12 +89,12 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -187,6 +187,23 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>2.4.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Enable dual publishing to AWS CodeArtifact alongside the existing Nexus deployment for the twitter4j repository. This is part of the Phase 1 Nexus-to-CodeArtifact migration (TOOLCM-4349). The version is bumped from 4.0.6-dmevents to 4.1.0-dmevents to mark this configuration change. Because module POMs do not inherit from the root POM (no `<parent>` element), the maven-deploy-plugin is added to each module individually rather than relying on parent inheritance.

## Change Summary

- **pom.xml** (root): Bumped `<version>` from `4.0.6-dmevents` to `4.1.0-dmevents`. Added a new top-level `<build><plugins>` section with `maven-deploy-plugin` v3.1.4 configured with a `us-deploy` execution that targets the CodeArtifact `altDeploymentRepository`. Added a `<repositories>` section with the `sproutsocial-us-releases` repository entry for dependency resolution. Existing Nexus `<distributionManagement>` block preserved unchanged.
- **twitter4j-core/pom.xml**: Bumped `<version>` to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution before `</plugins>` in `<build>`.
- **twitter4j-async/pom.xml**: Bumped `<version>` and `twitter4j-core` dependency version to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution.
- **twitter4j-stream/pom.xml**: Bumped `<version>`, `twitter4j-core` dependency, and `twitter4j-async` dependency versions to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution.
- **twitter4j-appengine/pom.xml**: Bumped `<version>` and `twitter4j-core` dependency version to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution.
- **twitter4j-http2-support/pom.xml**: Bumped `<version>` and `twitter4j-core` dependency version to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution.
- **twitter4j-media-support/pom.xml**: Bumped `<version>` and `twitter4j-core` dependency version to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution.
- **twitter4j-examples/pom.xml**: Bumped `<version>` and all 4 inter-module dependency versions (`twitter4j-core`, `twitter4j-async`, `twitter4j-stream`, `twitter4j-media-support`) to `4.1.0-dmevents`. Added `maven-deploy-plugin` with `us-deploy` execution.

## Related Links

- [TOOLCM-4386](https://sprout.atlassian.net/browse/TOOLCM-4386)
- [worker run #25870261278](https://github.com/sproutsocial/coding-agents/actions/runs/25870261278)


[TOOLCM-4386]: https://sprout.atlassian.net/browse/TOOLCM-4386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ