### PR TITLE
[TOOLCM-3826] Enable dual publish to CodeArtifact and Nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>pom</packaging>
     <name>twitter4j</name>
     <description>A Java library for the Twitter API</description>
@@ -55,6 +55,40 @@
           <url>http://nexus.int.sproutsocial.com:8081/nexus/content/repositories/releases</url>
         </repository>
     </distributionManagement>
+    <repositories>
+        <repository>
+            <id>sproutsocial-us-releases</id>
+            <url>https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+    <build>
+        <plugins>
+            <!-- Deploy to US CodeArtifact -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+                <executions>
+                    <execution>
+                        <id>us-deploy</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>deploy</goal>
+                        </goals>
+                        <configuration>
+                            <altDeploymentRepository>sproutsocial-us-releases::https://sproutsocial-412335208158.d.codeartifact.us-east-1.amazonaws.com/maven/mvn_releases/</altDeploymentRepository>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>release-sign-artifacts</id>

--- a/twitter4j-appengine/pom.xml
+++ b/twitter4j-appengine/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-appengine</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-appengine</name>
     <description>A Java library for the Twitter API</description>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>

--- a/twitter4j-async/pom.xml
+++ b/twitter4j-async/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-async</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-async</name>
     <description>A Java library for the Twitter API</description>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twitter4j-core/pom.xml
+++ b/twitter4j-core/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-core</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-core</name>
     <description>A Java library for the Twitter API</description>

--- a/twitter4j-examples/pom.xml
+++ b/twitter4j-examples/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-examples</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-examples</name>
     <description>A Java library for the Twitter API</description>
@@ -89,22 +89,22 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-stream</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-media-support</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twitter4j-http2-support/pom.xml
+++ b/twitter4j-http2-support/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-http2-support</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-http2-support</name>
     <description>A Java library for the Twitter API</description>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/twitter4j-media-support/pom.xml
+++ b/twitter4j-media-support/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.sproutsocial.org.twitter4j</groupId>
     <artifactId>twitter4j-media-support</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-media-support</name>
     <description>Twitter4J optional component adds multimedia support
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/twitter4j-stream/pom.xml
+++ b/twitter4j-stream/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.twitter4j</groupId>
     <artifactId>twitter4j-stream</artifactId>
-    <version>4.0.6-dmevents</version>
+    <version>4.1.0-dmevents</version>
     <packaging>jar</packaging>
     <name>twitter4j-stream</name>
     <description>A Java library for the Twitter API</description>
@@ -89,12 +89,12 @@
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
         </dependency>
         <dependency>
             <groupId>com.sproutsocial.org.twitter4j</groupId>
             <artifactId>twitter4j-async</artifactId>
-            <version>4.0.6-dmevents</version>
+            <version>4.1.0-dmevents</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Enables dual publishing of Maven artifacts to AWS CodeArtifact (`sproutsocial-us-releases`) alongside the existing Nexus deployment, as part of Sprout's Nexus → CodeArtifact migration.

## Changes
- Added `maven-deploy-plugin` (`us-deploy` execution, altDeploymentRepository) and the `sproutsocial-us-releases` CodeArtifact repository to the root pom only.
- Bumped version `4.0.6-dmevents` → `4.1.0-dmevents` across all modules (minor bump, preserving the fork's `-dmevents` qualifier since the version scheme is non-standard for this OSS fork).
- Existing Nexus `<distributionManagement>` is untouched — publishing to Nexus is preserved.

No CHANGELOG.md exists in this repo, so none was created (per skill guidance).

Jira: https://sprout.atlassian.net/browse/TOOLCM-3826

🤖 Generated with [Claude Code](https://claude.com/claude-code)